### PR TITLE
Add dummy-api to environments build

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,4 +14,5 @@ public_port=80
 
 scp -o StrictHostKeyChecking=no -i "$key" scripts/remote-deploy.sh "$ssh_hostname":/tmp/remote-deploy.sh
 revision_browser=$(scripts/latest-revision.sh https://github.com/libero/browser.git)
-ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" PUBLIC_PORT=${public_port} REVISION_BROWSER="$revision_browser" /tmp/remote-deploy.sh
+revision_dummy_api=$(scripts/latest-revision.sh https://github.com/libero/dummy-api.git)
+ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" PUBLIC_PORT=${public_port} REVISION_BROWSER="$revision_browser" REVISION_DUMMY_API="$revision_dummy_api" /tmp/remote-deploy.sh

--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -23,4 +23,8 @@ if [ -n "$REVISION_BROWSER" ]; then
     sed -i -e "s/^REVISION_BROWSER=.*$/REVISION_BROWSER=$REVISION_BROWSER/g" .env
 fi
 
+if [ -n "$REVISION_DUMMY_API" ]; then
+    sed -i -e "s/^REVISION_DUMMY_API=.*$/REVISION_DUMMY_API=$REVISION_DUMMY_API/g" .env
+fi
+
 docker-compose up --force-recreate -d


### PR DESCRIPTION
For https://github.com/libero/libero/issues/23

Practically won't do anything until https://github.com/libero/sample-configuration/pull/4 is in.