### PR TITLE
Check out sample-configuration submodules

### DIFF
--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -4,11 +4,12 @@ set -ex
 
 cd /tmp
 if [ ! -d sample-configuration ]; then
-    git clone https://github.com/libero/sample-configuration
+    git clone https://github.com/libero/sample-configuration --recurse-submodules
     cd sample-configuration
 else
     cd sample-configuration
     git pull origin master
+    git submodule update
 fi
 
 if [ ! -f .env ]; then


### PR DESCRIPTION
The first one when we have to do this, as it's not checked out by Travis CI. Should have happened sooner, but `environments` hasn't been triggered.