### PR TITLE
Smoke test on correct port

### DIFF
--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -32,4 +32,6 @@ fi
 # assume all service are stateless
 docker-compose down -v
 docker-compose up --force-recreate -d
-.travis/smoke-test.sh
+
+# compare PUBLIC_PORT in .env, if provided
+HTTP_PORT=80 .travis/smoke-test.sh


### PR DESCRIPTION
Wouldn't couple `HTTP_PORT` from `sample-configuration` (may not be public) with `PUBLIC_PORT` from here (may have HTTPS in the future, etc). For now the only connection will be this explicit assignment.