### PR TITLE
Specify project name

### DIFF
--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -34,4 +34,4 @@ docker-compose down -v
 docker-compose up --force-recreate -d
 
 # compare PUBLIC_PORT in .env, if provided
-HTTP_PORT=80 .travis/smoke-test.sh
+COMPOSE_PROJECT_NAME=sample-configuration HTTP_PORT=80 .travis/smoke-test.sh


### PR DESCRIPTION
The `docker-compose` used here is our recent version, so it's using hyphens in folder names.