### PR TITLE
Deploy latest pattern-library revision

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,4 +15,5 @@ public_port=80
 scp -o StrictHostKeyChecking=no -i "$key" scripts/remote-deploy.sh "$ssh_hostname":/tmp/remote-deploy.sh
 revision_browser=$(scripts/latest-revision.sh https://github.com/libero/browser.git)
 revision_dummy_api=$(scripts/latest-revision.sh https://github.com/libero/dummy-api.git)
-ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" PUBLIC_PORT=${public_port} REVISION_BROWSER="$revision_browser" REVISION_DUMMY_API="$revision_dummy_api" /tmp/remote-deploy.sh
+revision_pattern_library=$(scripts/latest-revision.sh https://github.com/libero/pattern-library.git)
+ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" PUBLIC_PORT=${public_port} REVISION_BROWSER="$revision_browser" REVISION_DUMMY_API="$revision_dummy_api" REVISION_PATTERN_LIBRARY="$revision_pattern_library" /tmp/remote-deploy.sh

--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -28,6 +28,10 @@ if [ -n "$REVISION_DUMMY_API" ]; then
     sed -i -e "s/^REVISION_DUMMY_API=.*$/REVISION_DUMMY_API=$REVISION_DUMMY_API/g" .env
 fi
 
+if [ -n "$REVISION_PATTERN_LIBRARY" ]; then
+    sed -i -e "s/^REVISION_PATTERN_LIBRARY=.*$/REVISION_PATTERN_LIBRARY=$REVISION_PATTERN_LIBRARY/g" .env
+fi
+
 # avoid nginx+fpm shared volumes persisting files from older releases
 # assume all service are stateless
 docker-compose down -v


### PR DESCRIPTION
`deploy.sh` uploads and runs `remote-deploy.sh` onto a server. It passes environment variables to it that get stored into a `.env` file during the deploy.

The final command of the deploy is just a embellished `docker-compose up` that relies on these environments to switch the tags of the container images that are run.