### PR TITLE
Make the number of applications scalable

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -25,4 +25,4 @@ do
     environment="${environment} $environment_variable_name=${revision}"
 done
 
-ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" PUBLIC_PORT=${public_port} $environment /tmp/remote-deploy.sh
+ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" PUBLIC_PORT=${public_port} "$environment" /tmp/remote-deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,8 @@ declare environment
 for application in "${applications[@]}"
 do
     revision=$(scripts/latest-revision.sh "https://github.com/libero/${application}.git")
-    environment_variable_name="REVISION_$(echo $application | tr a-z A-Z | tr - _)"
+    # shellcheck disable=SC2018 disable=SC2019
+    environment_variable_name="REVISION_$(echo "$application" | tr a-z A-Z | tr - _)"
     environment="${environment} $environment_variable_name=${revision}"
 done
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,7 @@ declare environment
 for application in "${applications[@]}"
 do
     revision=$(scripts/latest-revision.sh "https://github.com/libero/${application}.git")
-    environment_variable_name="REVISION_$(echo $application | tr a-z A-Z | tr - _)"
+    environment_variable_name="REVISION_$(echo "$application" | tr '[:lower]' '[:upper]' | tr - _)"
     environment="${environment} $environment_variable_name=${revision}"
 done
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,7 +13,16 @@ key="$2"
 public_port=80
 
 scp -o StrictHostKeyChecking=no -i "$key" scripts/remote-deploy.sh "$ssh_hostname":/tmp/remote-deploy.sh
-revision_browser=$(scripts/latest-revision.sh https://github.com/libero/browser.git)
-revision_dummy_api=$(scripts/latest-revision.sh https://github.com/libero/dummy-api.git)
-revision_pattern_library=$(scripts/latest-revision.sh https://github.com/libero/pattern-library.git)
-ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" PUBLIC_PORT=${public_port} REVISION_BROWSER="$revision_browser" REVISION_DUMMY_API="$revision_dummy_api" REVISION_PATTERN_LIBRARY="$revision_pattern_library" /tmp/remote-deploy.sh
+
+# list of applications
+declare -a applications=(browser dummy-api pattern-library)
+# environment variables string
+declare environment
+for application in "${applications[@]}"
+do
+    revision=$(scripts/latest-revision.sh "https://github.com/libero/${application}.git")
+    environment_variable_name="REVISION_$(echo $application | tr a-z A-Z | tr - _)"
+    environment="${environment} $environment_variable_name=${revision}"
+done
+
+ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" PUBLIC_PORT=${public_port} $environment /tmp/remote-deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,7 @@ declare environment
 for application in "${applications[@]}"
 do
     revision=$(scripts/latest-revision.sh "https://github.com/libero/${application}.git")
-    environment_variable_name="REVISION_$(echo "$application" | tr '[:lower]' '[:upper]' | tr - _)"
+    environment_variable_name="REVISION_$(echo $application | tr a-z A-Z | tr - _)"
     environment="${environment} $environment_variable_name=${revision}"
 done
 

--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -20,17 +20,16 @@ if [ -n "$PUBLIC_PORT" ]; then
     sed -i -e "s/^PUBLIC_PORT=.*$/PUBLIC_PORT=$PUBLIC_PORT/g" .env
 fi
 
-if [ -n "$REVISION_BROWSER" ]; then
-    sed -i -e "s/^REVISION_BROWSER=.*$/REVISION_BROWSER=$REVISION_BROWSER/g" .env
-fi
-
-if [ -n "$REVISION_DUMMY_API" ]; then
-    sed -i -e "s/^REVISION_DUMMY_API=.*$/REVISION_DUMMY_API=$REVISION_DUMMY_API/g" .env
-fi
-
-if [ -n "$REVISION_PATTERN_LIBRARY" ]; then
-    sed -i -e "s/^REVISION_PATTERN_LIBRARY=.*$/REVISION_PATTERN_LIBRARY=$REVISION_PATTERN_LIBRARY/g" .env
-fi
+declare -A revisions=()
+revisions[BROWSER]="$REVISION_BROWSER"
+revisions[DUMMY_API]="$REVISION_DUMMY_API"
+revisions[PATTERN_LIBRARY]="$REVISION_PATTERN_LIBRARY"
+for application in "${!revisions[@]}"
+do
+    if [ -n "${revisions[$application]}" ]; then
+        sed -i -e "s/^REVISION_${application}=.*$/REVISION_${application}=${revisions[$application]}/g" .env
+    fi
+done
 
 # avoid nginx+fpm shared volumes persisting files from older releases
 # assume all service are stateless


### PR DESCRIPTION
For https://github.com/libero/libero/issues/117 but also `search`. Adding an application becomes a matter of two lines. I do realize this is intricate bash scripting.

`scripts/deploy.sh` runs in a pipeline and connects to the server where the `unstable` environment lives via SSH, running `scripts/remote-deploy.sh`. It passes in environment variables with the latest revisions (commits, which coincide with Docker image tags) of the various services.

`scripts/remote-deploy.sh` runs on that server and stores the revisions into a local `.env` file. The `sample-configuration` repository containing the `docker-compose` configuration runs all the containers there according to these revisions.