### PR TITLE
Deploy in $HOME folder

### DIFF
--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -2,7 +2,7 @@
 # shipped to a remote virtual machine to deploy sample-configuration there
 set -ex
 
-cd /tmp
+cd "$HOME"
 if [ ! -d sample-configuration ]; then
     git clone https://github.com/libero/sample-configuration --recurse-submodules
     cd sample-configuration


### PR DESCRIPTION
Makes deployment more robust to reboots: https://github.com/libero/environments/pull/20#issuecomment-473245129

`$HOME` is currently `/home/ubuntu`.