### PR TITLE
Add jats-ingester to deploy list

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,7 +18,7 @@ ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" mkdir -p secrets/
 scp -o StrictHostKeyChecking=no -i "$key" -r secrets/"$environment_name"/* "$ssh_hostname":secrets/
 
 # list of applications
-declare -a applications=(browser content-store dummy-api pattern-library search)
+declare -a applications=(browser content-store dummy-api jats-ingester pattern-library search)
 # environment variables string
 declare environment
 for application in "${applications[@]}"

--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -25,6 +25,7 @@ declare -A revisions=()
 revisions[CONTENT_STORE]="$REVISION_CONTENT_STORE"
 revisions[BROWSER]="$REVISION_BROWSER"
 revisions[DUMMY_API]="$REVISION_DUMMY_API"
+revisions[JATS_INGESTER]="$REVISION_JATS_INGESTER"
 revisions[PATTERN_LIBRARY]="$REVISION_PATTERN_LIBRARY"
 revisions[SEARCH]="$REVISION_SEARCH"
 for application in "${!revisions[@]}"


### PR DESCRIPTION
(maybe) completes https://github.com/libero/libero/issues/154

Without this, the `latest` cached tag will continue to be used, with nothing forcing a new Docker image during this repository's deploy.