### PR TITLE
Configure and pass on HTTP and HTTPS ports

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,7 +11,8 @@ fi
 environment_name="$1"
 ssh_hostname="$2"
 key="$3"
-public_port=80
+public_port_http=80
+public_port_https=443
 
 scp -o StrictHostKeyChecking=no -i "$key" scripts/remote-deploy.sh "$ssh_hostname":/tmp/remote-deploy.sh
 ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" mkdir -p files/
@@ -30,4 +31,4 @@ do
     environment="${environment} $environment_variable_name=${revision}"
 done
 
-ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" PUBLIC_PORT=${public_port} "$environment" /tmp/remote-deploy.sh
+ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" PUBLIC_PORT_HTTP="${public_port_http}" PUBLIC_PORT_HTTPS="${public_port_https}" "$environment" /tmp/remote-deploy.sh

--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -16,8 +16,12 @@ if [ ! -f .env ]; then
     cp .env.dist .env
 fi
 
-if [ -n "$PUBLIC_PORT" ]; then
-    sed -i -e "s/^PUBLIC_PORT=.*$/PUBLIC_PORT=$PUBLIC_PORT/g" .env
+if [ -n "$PUBLIC_PORT_HTTP" ]; then
+    sed -i -e "s/^PUBLIC_PORT_HTTP=.*$/PUBLIC_PORT_HTTP=$PUBLIC_PORT_HTTP/g" .env
+fi
+
+if [ -n "$PUBLIC_PORT_HTTPS" ]; then
+    sed -i -e "s/^PUBLIC_PORT_HTTPS=.*$/PUBLIC_PORT_HTTPS=$PUBLIC_PORT_HTTP/g" .env
 fi
 
 echo "Setting revisions of applications"
@@ -53,6 +57,7 @@ docker-compose -f docker-compose.yml -f docker-compose.secrets.yml down --remove
 # (re)start containers
 docker-compose -f docker-compose.yml -f docker-compose.secrets.yml up --force-recreate --detach
 # waits and executes smoke tests
-COMPOSE_PROJECT_NAME=sample-configuration HTTP_PORT=80 .travis/smoke-test.sh
+# HTTP_PORT to be removed after backward compatibility
+COMPOSE_PROJECT_NAME=sample-configuration HTTP_PORT=80 PUBLIC_PORT_HTTP="${PUBLIC_PORT_HTTP}" PUBLIC_PORT_HTTPS="${PUBLIC_PORT_HTTPS}" .travis/smoke-test.sh
 # populate the services
 .docker/populate-services.sh

--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -21,7 +21,7 @@ if [ -n "$PUBLIC_PORT_HTTP" ]; then
 fi
 
 if [ -n "$PUBLIC_PORT_HTTPS" ]; then
-    sed -i -e "s/^PUBLIC_PORT_HTTPS=.*$/PUBLIC_PORT_HTTPS=$PUBLIC_PORT_HTTP/g" .env
+    sed -i -e "s/^PUBLIC_PORT_HTTPS=.*$/PUBLIC_PORT_HTTPS=$PUBLIC_PORT_HTTPS/g" .env
 fi
 
 echo "Setting revisions of applications"


### PR DESCRIPTION
Especially helpful in case of first deploys, as the defaults are `8080` and `8443` and would break unless `.env` is modified manually (did this when we re-created a server).

Also helpful for smoke tests to know the ports to hit rather than guessing.