### PR TITLE
Use latest tags to find out revisions to deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,6 +14,7 @@ key="$3"
 public_port_http=80
 public_port_https=443
 branch_name="${BRANCH_NAME:-master}"
+docker_libero_namespace="liberoadmin"
 
 scp -o StrictHostKeyChecking=no -i "$key" scripts/remote-deploy.sh "$ssh_hostname":/tmp/remote-deploy.sh
 ssh -o StrictHostKeyChecking=no -i "$key" "$ssh_hostname" mkdir -p files/
@@ -27,7 +28,7 @@ declare -a applications=(browser content-store dummy-api jats-ingester pattern-l
 declare environment
 for application in "${applications[@]}"
 do
-    revision=$(scripts/latest-revision.sh "https://github.com/libero/${application}.git")
+    revision=$(scripts/latest-revision.sh "${docker_libero_namespace}/${application}")
     environment_variable_name="REVISION_$(echo "$application" | tr '[:lower:]' '[:upper:]' | tr - _)"
     environment="${environment} $environment_variable_name=${revision}"
 done

--- a/scripts/latest-revision.sh
+++ b/scripts/latest-revision.sh
@@ -1,18 +1,16 @@
 #!/bin/bash
-# finds out the commit sha of the latest revision of a repository,
-# with minimal cloning
+# finds out the commit sha originating a latest Docker image,
+# by pulling it and reading labels
 set -e
 
 if [ "$#" -ne 1 ]; then
-    echo "USAGE $0 GIT_REMOTE_REPOSITORY"
+    echo "USAGE $0 DOCKER_IMAGE [TAG]"
+    echo "Example: $0 liberoadmin/browser latest"
     exit 1
 fi
 
-remote="$1"
-folder=$(basename "$remote")
+image_name="$1"
+tag="${2:-latest}"
 
-cd remotes
-rm -rf "./$folder"
-git clone -v --depth=1 "$remote" "$folder"
-cd "$folder"
-git rev-parse master
+docker pull "${image_name}:${tag}" 1>&2
+docker inspect liberoadmin/search:latest | jq -r '.[0].Config.Labels."org.opencontainers.image.revision"'

--- a/scripts/latest-revision.sh
+++ b/scripts/latest-revision.sh
@@ -13,4 +13,4 @@ image_name="$1"
 tag="${2:-latest}"
 
 docker pull "${image_name}:${tag}" 1>&2
-docker inspect liberoadmin/search:latest | jq -r '.[0].Config.Labels."org.opencontainers.image.revision"'
+docker inspect "${image_name}:${tag}" | jq -r '.[0].Config.Labels."org.opencontainers.image.revision"'


### PR DESCRIPTION
Solves failed deployments like https://travis-ci.com/libero/environments/builds/118456093 where `master` has a new commit that can be cloned, but the image hasn't been pushed yet to Docker Hub.

Relies on a [standard label](https://github.com/libero/search/pull/28) being adopted across projects however.